### PR TITLE
macOS support implementation, automated build process for macOS, lots of documentation, WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,5 @@ build/
 # mac stuff
 *.DS_Store
 
+# local stuf
+local-data/

--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,13 @@ deps/hidapi-win
 
 #Fusion
 deps/Fusion
+
+# build artifacts
+build/
+
+# IDE stuff
+.vscode
+
+# mac stuff
+*.DS_Store
+

--- a/AirAPI_Windows.cpp
+++ b/AirAPI_Windows.cpp
@@ -395,6 +395,7 @@ void *track(void *lpParam) {
 // DWORD is typealias of: unsigned int
 // 
 // must be format: void *worker_thread(void *arg)
+int brightness = 0;
 void *interface4Handler(void *lpParam) {
 	std::cout << "interface4Handler invoked" << std::endl;
 
@@ -606,8 +607,6 @@ float* GetEuler()
 	signalled = true;
 	return e;
 }
-
-int brightness = 0;
 
 int GetBrightness()
 {

--- a/AirAPI_Windows.cpp
+++ b/AirAPI_Windows.cpp
@@ -448,7 +448,7 @@ void *interface4Handler(void *lpParam) {
 				break;
 
 			default:
-				std::cout << "Brightness: default inner switch case" << std::endl;
+				// std::cout << "Brightness: default inner switch case" << std::endl;
 				break;
 			}
 		} else {

--- a/AirAPI_Windows.h
+++ b/AirAPI_Windows.h
@@ -1,9 +1,24 @@
+// TODO: post-draft pr, remove bg / investigation comments and links
+
+// macOS compatibility
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+
+#ifdef AIRAPI_EXPORTS
+#define AIR_API __attribute__((visibility("default")))
+#else
+#define AIR_API
+#endif
+
+#else
+
 #pragma once
 
 #ifdef AIRAPI_EXPORTS
 #define AIR_API __declspec(dllexport)
 #else
 #define AIR_API __declspec(dllimport)
+#endif
+
 #endif
 
 //Function to start connection to Air

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+# TODO: post-draft pr, remove bg / investigation comments and links
+# also-- see if all is required and drop anything not mandatory
+cmake_minimum_required(VERSION 3.17)
+
+# macos build config
+# project config
+project(AirAPI_Mac)
+
+# compiler config
+SET(CMAKE_CXX_COMPILER             "/usr/bin/clang++")
+SET(CMAKE_CXX_FLAGS                "-Wall")
+SET(CMAKE_CXX_FLAGS_DEBUG          "-g")
+SET(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
+SET(CMAKE_CXX_FLAGS_RELEASE        "-O4 -DNDEBUG")
+SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_CXX_STANDARD 17)
+
+# deps and sources config
+set(HIDAPI_HEADER_PATH ${HIDAPI_INCLUDE_DIR}) # sourced from env @ cmake --build
+set(MAC_HEADER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/platforms/mac")
+set(SOURCES ./AirAPI_Windows.cpp "${HIDAPI_HEADER_PATH}" "${MAC_HEADER_PATH}")
+
+# declare a lib, not executable
+add_library(AirAPI_Mac STATIC ${SOURCES})
+
+# set library directory
+set(HIDAPI_INCLUDE_DIR "$HIDAPI_INCLUDE_DIR")
+
+# include dirs
+target_include_directories(AirAPI_Mac PUBLIC "${HIDAPI_INCLUDE_DIR}")
+target_include_directories(AirAPI_Mac INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# link specific object files we need
+target_link_libraries(AirAPI_Mac ${FUSION_LIB_DIR}/libFusion.a)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 MSmithDev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ To use the precompiled [AirAPI_Windows.dll](https://github.com/MSmithDev/AirAPI_
 
 # Building from source
 
-## Getting hidapi
+## Windows
+
+### Getting hidapi
 Get the latest hidapi-win.zip from [here](https://github.com/libusb/hidapi/releases).
 
 unzip hidapi-win.zip to "deps" folder ("deps/hidapi-win").
 
 
 
-## Build Fusion
-### Clone this project
+### Build Fusion
+#### Clone this project
 Goto project directory
 ```
 cd AirAPI_Windows
@@ -48,5 +50,231 @@ cmake .
 
 Open the Project.sln and build the project <br>
 You should have a "deps/Fusion/Fusion/Release/Fusion.lib" file.
-### Build AirAPI_Windows DLL 
+#### Build AirAPI_Windows DLL 
 Open AirAPI_Windows.sln and make sure "Release" and "x64" are set and build.
+
+## MacOS (Beta)
+
+Features:
+
+- C++ library compilation and linking for macOS
+- Compatible with **Swift** for macOS app development for **BOTH Intel AND Arm based Macs**
+- Same interfaces and features as the Windows version
+- Compatible with the latest macOS releases
+- Builds and runs alongside the Windows version with no additional configuration steps
+
+Requirements:
+
+- macOS v13+ (ventura)
+- Same dependency requirements as Windows, but you need to install / link them differently (windows instructions don't apply to the macOS build process)
+    - `Fusion`
+    - `hdiapi`
+
+
+Known issues:
+
+- the brightness API doesn't seem to produce any data
+
+    - looks like an underlying issue in the C++, needs investigation
+
+
+### Preparing to build from source
+
+Make sure you have the tools to build this project for macOS Ventura:
+
+- Install [cmake](https://formulae.brew.sh/formula/cmake) from Homebrew
+
+- Make sure you have Apple’s developer tools installed:
+    - Get the latest version of  Xcode [from the Mac App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12)
+    - Make sure you have the latest toolchain by running: `xcode-select --install`
+
+- 
+
+Build the dependencies locally for macOS from source.
+
+
+### Compile Fusion for macOS
+
+You'll need to build `Fusion` locally for macOS from source:
+
+- `cd` to the root of this repository
+
+- run `git submodule update`
+
+- `cd` from project root to the `Fusion` package with `cd ./deps/Fusion/Fusion`
+
+
+From here the instructions are different from the Windows build becuase you need both a header file AND a compiled c library (Fusion.h and libfusion.a) for macOS:
+
+- create build output some folders to organize cmake output
+
+    - run `mkdir -p ./build/lib && mkdir ./build/include`
+
+- run `cmake -B build -DCMAKE_BUILD_TYPE=Release`
+
+    - cmake artifacts will be created within the `build` directory
+
+- run `cmake --build build`
+
+    - this produces a static library `libFusion.a` within `build`
+
+- organize cmake artifacts into a conventional c++ dir structure:
+
+    - run `cp ./*.h ./build/include` to copy the library’s c++ headers
+    - run `cp ./build/libFusion.a ./build/lib` to move the static library to the `./build/lib`
+
+
+if you run `tree -I 'CMakeFiles' ./build` the directory structure should like this:
+<br>
+
+```bash
+# install tree if you don’t have it:
+# brew install tree
+
+$ tree -I 'CMakeFiles' ./build
+
+./build
+├── CMakeCache.txt
+├── Makefile
+├── cmake_install.cmake
+├── include
+│   ├── Fusion.h
+│   ├── FusionAhrs.h
+│   ├── FusionAxes.h
+│   ├── FusionCalibration.h
+│   ├── FusionCompass.h
+│   ├── FusionMath.h
+│   └── FusionOffset.h
+├── lib
+│   └── libFusion.a
+└── libFusion.a
+
+3 directories, 12 files
+```
+<br>
+
+
+#### Export Fusion paths
+
+
+You will need to link `AirAPI_Mac` the the `Fusion` library for macOS later on.
+
+We suggest you export those paths by running the following from `deps/Fusion/Fusion`:
+
+
+```bash
+export FUSION_BUILD_DIR="$(pwd)"
+export FUSION_LIB_DIR="$FUSION_BUILD_DIR/lib"
+export FUSION_INCLUDE_DIR="$FUSION_BUILD_DIR/include"
+```
+
+the output of both:
+
+- `echo $FUSION_LIB_DIR` 
+
+- `echo $FUSION_INCLUDE_DIR` 
+
+should display the paths you will need later when compiling `AirAPI_Mac` with cmake
+
+<br>
+Alternatively, you can also installl `Fusion` for macOS by [building the project from source](https://github.com/xioTechnologies/Fusion) directly.
+<br><br>
+
+
+### Compile hidapi for macOS
+
+Installing `hidapi` with Homebrew is a bit easier:
+
+- run: `brew update` 
+
+- run: `brew install hidapi`
+
+The installation output should live in `/usr/local/Cellar/hidapi` by default.
+
+(You can confirm the istallation location at any time by running `brew info hidapi`, which will list the installation path)
+<br>
+
+
+### Export hidapi paths
+
+
+Assuming that you used `brew` to install `hidapi`, export the paths for `hidapi`:
+
+```bash
+export HIDAPI_ROOT_DIR="/usr/local/Cellar/hidapi/0.13.1"
+export HIDAPI_LIB_DIR="$HIDAPI_ROOT_DIR/lib"
+export HIDAPI_INCLUDE_DIR="$HIDAPI_ROOT_DIR/include"
+```
+*Note: 
+version 0.13.1 was the latest at the time of writing this. run **brew info hidapi** to verify your current version*
+
+
+the output of both:
+
+- `echo $HIDAPI_LIB_DIR` 
+
+- `echo $HIDAPI_INCLUDE_DIR` 
+
+should display the paths you will need later when compiling `AirAPI_Mac` with cmake
+
+
+<br>
+Alternatively, you can also installl `hidapi` for macOS by [building the project from source](https://github.com/libusb/hidapi) directly.
+<br><br>
+
+
+## Building a macOS compatible c++ library
+<br>
+Assuming you have all of the tools and dependencies above installed:
+
+- Clone this repository
+
+- `cd` to the root of the reopsitory
+
+
+**Required**: to run the included `build-mac.sh` script, these environment variables *must* be exported in the current terminal (details above):
+
+    - `$FUSION_LIB_DIR`
+    - `$FUSION_INCLUDE_DIR`
+    - `$HIDAPI_LIB_DIR`
+    - `$HIDAPI_INCLUDE_DIR`
+
+
+### Run the build-mac script
+
+
+From the root of this repo:
+
+- `zsh ./platforms/mac/build-mac.sh`
+
+
+After a fairly quick build process, you should see the following:
+
+```bash
+macOS build complete.
+
+header path:
+(your local path)/AirAPI_Windows/build/mac/include/AirAPI_Mac.h
+
+library path:
+(your local path)/AirAPI_Windows/build/mac/lib/libAirAPI_Mac.a
+```
+
+
+If you see this ^^ message=, congrats, you’ve built `AirAPI_Mac` successfully.
+
+
+## Building a compatible Swift Framework for macOS
+
+Although c++ and Swift are technically interoperable, using a c++ library with Swift requires an Objective-C implementation layer in between.
+
+### (INSTRUCTIONS AND EXAMPLE PROJECT COMING NEXT)
+
+
+#### Disclaimer about this proejct
+
+(and open-source software generally)
+
+As always, please understand the risks including hardware / software data loss or damage, security issues, etc. when working with code from the internet. We're doing our best, but the maintainers of this repository (or whoever you got it from), collaborators, etc make no guarantees, make no warranties, and are not responsible for anything that happens as a result of this code or any of its dependencies. You are fully, 100% responsible for anything you do with this work, and by simply being in possession of this code (or any derivitive work that includes, depends on, or references this project) that you are on your own and fully liable for whatever happens next. 
+
+In general: if you don't know what it does, don't download or run it.

--- a/mac.h
+++ b/mac.h
@@ -1,0 +1,33 @@
+// TODO: post-draft pr, remove bg / investigation comments and links
+
+#include <cstdint>
+#include <pthread.h>
+
+// Windows types and typealiases: https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types?redirectedfrom=MSDN
+typedef void *LPVOID; // pointer to any type, used in std windows lib functions signatures: 
+typedef pthread_t *HANDLE; // void pointer alias in windows: https://stackoverflow.com/a/34870510/11274568
+typedef HANDLE HINSTANCE;
+typedef HINSTANCE HMODULE;
+typedef int BOOL;
+typedef BOOL TRUE;
+typedef BOOL FALSE;
+
+// explicit typedefs for macOS: https://cplusplus.com/forum/general/7306/
+// DEBUG: trying alternate defs: https://puredata.info/dev/gemwiki/FreeFrame
+typedef unsigned int DWORD; // relating to windows specific type
+
+// typedef uint32_t DWORD;
+typedef unsigned char BYTE;
+
+// typedef int8_t  BYTE;
+// unsure if I need these typealiases
+// TODO: review later
+typedef uint8_t  CHAR;
+typedef uint16_t WORD;
+typedef int16_t SHORT;
+typedef int32_t LONG;
+
+// WINAPI / CALLPACK is a standard function call alias in windows.h lib
+#define WINAPI __stdcall;
+#define APIENTRY WINAPI;
+#define CALLBACK __stdcall;

--- a/platforms/mac/AirAPI_Mac.h
+++ b/platforms/mac/AirAPI_Mac.h
@@ -1,0 +1,29 @@
+// AirAPI_Mac.h
+//
+// Created by GigabiteLabs
+// Swift Version: 5.0
+// Copyright © 2023 GigabiteLabs. All rights reserved.
+//
+
+#pragma once
+
+#define AIRAPI_MAC __attribute__((visibility("public")))
+
+#if __cplusplus
+extern "C" {
+#endif
+
+//Function to start connection to Air
+int StartConnection(void);
+//Function to stop connection to Air
+int StopConnection(void);
+//Function to get quaternion
+float * GetQuaternion(void);
+//Function to get euler
+float * GetEuler(void);
+//Function to get brightness
+int GetBrightness(void);
+
+#if __cplusplus
+}   // Extern C
+#endif

--- a/platforms/mac/build-mac.sh
+++ b/platforms/mac/build-mac.sh
@@ -15,7 +15,7 @@ mkdir -p $BUILD_MAC_LIB_DIR
 mkdir -p $BUILD_MAC_INCLUDE_DIR
 
 # copy
-cp "$PROJ_ROOT_DIR/AirAPI_Windows.h" "$BUILD_MAC_INCLUDE_DIR/AirAPI_Mac.h" &&
+cp "$PROJ_ROOT_DIR/platforms/mac/AirAPI_Mac.h" "$BUILD_MAC_INCLUDE_DIR/AirAPI_Mac.h" &&
 
 # run cmake build to release
 cmake -B $BUILD_MAC_DIR -DCMAKE_BUILD_TYPE=Release && cmake --build $BUILD_MAC_DIR

--- a/platforms/mac/build-mac.sh
+++ b/platforms/mac/build-mac.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# build vars
+PROJ_NAME="AirAPI_Mac"
+PROJ_LIB_NAME="lib$PROJ_NAME.a"
+PROJ_LIB_HEADER_FILENAME="$PROJ_NAME.h"
+PROJ_ROOT_DIR="$(pwd)"
+BUILD_MAC_DIR="$PROJ_ROOT_DIR/build/mac"
+BUILD_MAC_LIB_DIR=$BUILD_MAC_DIR/lib
+BUILD_MAC_INCLUDE_DIR=$BUILD_MAC_DIR/include
+
+# setup dirs
+mkdir -p $BUILD_MAC_DIR
+mkdir -p $BUILD_MAC_LIB_DIR
+mkdir -p $BUILD_MAC_INCLUDE_DIR
+
+# copy
+cp "$PROJ_ROOT_DIR/AirAPI_Windows.h" "$BUILD_MAC_INCLUDE_DIR/AirAPI_Mac.h" &&
+
+# run cmake build to release
+cmake -B $BUILD_MAC_DIR -DCMAKE_BUILD_TYPE=Release && cmake --build $BUILD_MAC_DIR
+
+# copy output to lib dir
+mv "$BUILD_MAC_DIR/libAirAPI_Mac.a" $BUILD_MAC_LIB_DIR
+
+# build new output paths
+LIB_PATH="$BUILD_MAC_LIB_DIR/$PROJ_LIB_NAME"
+HEADER_PATH="$BUILD_MAC_INCLUDE_DIR/$PROJ_LIB_HEADER_FILENAME"
+
+# check if successful
+if [ -f "$LIB_PATH" ] && [ -f "$HEADER_PATH" ]; then
+    # report success
+    printf "\n\nmacOS build script finished, the compiled framework paths are:\n\n"
+    printf "header path:\n$HEADER_PATH\n\n"
+    printf "library path:\n$LIB_PATH\n\n"
+else
+    printf "\nERROR: the script did not finish building successfully.\n\nSee logs above.\n"
+fi


### PR DESCRIPTION
- C++ adapted for macOS
- Quarternion & Euler measurements verified working on macOS (in Xcode / Swift)
- Automated build process added to mostly automate the compilation tasks for mac
- Dedicated build artifacts and scripts directory for each platform-- I think we should update with Windows (and eventually Linux) build processes respectively.
- Detailed instructions added to README (with disclaimer)
- Fully tested with a working macOS application in Swift(!)
(sample project and demo content for that will be posted on the draft PR shortly)

4/2/23: updated draft PR with fixes (for my own bugs)
- fixed bug related to brightness sensor reading
- build script fixes for macOS builds & build script update
- local-data dir added to gitignore so we have somewhere to put non-committed scripts / resources

Knowns / issues:
- AirAPI_Windows.cpp will only compile for macOS in this version (most Windows stuff removed or commented)
~~I need feedback on my implementation of pthread. It does the job, but it produces a crash upon exit in Swift (seems to be crashing the main thread, but I can't tell if it is swift or C++ related~~ (nvm, it was a local issues with Swift threading)

Understood that this is a is WIP, it may need correction / fixes / stylistic changes. Please tell he how to improve, I'm to learn and to help build with this project however I can.