### PR TITLE
 Fixed interface4Handler, Fusion filepath, and project type default.

### DIFF
--- a/AirAPI_Windows.cpp
+++ b/AirAPI_Windows.cpp
@@ -359,7 +359,7 @@ DWORD WINAPI interface4Handler(LPVOID lpParam) {
 	std::array<uint8_t, 17> initBrightness = { 0x00, 0xfd, 0x1e, 0xb9, 0xf0, 0x68, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03 };
 	hid_write(device4, initBrightness.data(), initBrightness.size());
 	
-
+	
 	while (g_isListening) {
 		std::array<uint8_t, 65> recv = {};
 		int res = hid_read(device4, recv.data(), recv.size());
@@ -396,6 +396,7 @@ DWORD WINAPI interface4Handler(LPVOID lpParam) {
 			}
 		}
 	}
+	return 0;
 }
 
 

--- a/AirAPI_Windows.cpp
+++ b/AirAPI_Windows.cpp
@@ -10,6 +10,8 @@
 //Air USB VID and PID
 #define AIR_VID 0x3318
 #define AIR_PID 0x0424
+#define AIR_2_PID 0x0428
+#define AIR_2_PRO_PID 0x0432
 
 //Is Tracking
 bool g_isTracking = false;
@@ -215,8 +217,27 @@ process_accel(const int32_t in_accel[3], float out_vec[])
 static hid_device*
 open_device()
 {
-	struct hid_device_info* devs = hid_enumerate(AIR_VID, AIR_PID);
-	struct hid_device_info* cur_dev = devs;
+	struct hid_device_info* devs = NULL;
+	struct hid_device_info* devs_1 = hid_enumerate(AIR_VID, AIR_PID);
+	struct hid_device_info* devs_2 = hid_enumerate(AIR_VID, AIR_2_PID);
+	struct hid_device_info* devs_2_pro = hid_enumerate(AIR_VID, AIR_2_PRO_PID);
+	
+	struct hid_device_info* cur_dev = NULL;
+
+	if (devs_1 != NULL) {
+		cur_dev = devs_1;
+		devs = devs_1;
+	}
+	else if (devs_2 != NULL) {
+		cur_dev = devs_2;
+		devs = devs_2;
+
+	}
+	else if (devs_2_pro != NULL) {
+		cur_dev = devs_2_pro;
+		devs = devs_2_pro;
+	}
+
 	hid_device* device = NULL;
 
 	while (devs) {
@@ -236,8 +257,26 @@ open_device()
 static hid_device*
 open_device4()
 {
-	struct hid_device_info* devs = hid_enumerate(AIR_VID, AIR_PID);
-	struct hid_device_info* cur_dev = devs;
+	struct hid_device_info* devs = NULL;
+	struct hid_device_info* devs_1 = hid_enumerate(AIR_VID, AIR_PID);
+	struct hid_device_info* devs_2 = hid_enumerate(AIR_VID, AIR_2_PID);
+	struct hid_device_info* devs_2_pro = hid_enumerate(AIR_VID, AIR_2_PRO_PID);
+
+	struct hid_device_info* cur_dev = NULL;
+
+	if (devs_1 != NULL) {
+		cur_dev = devs_1;
+		devs = devs_1;
+	}
+	else if (devs_2 != NULL) {
+		cur_dev = devs_2;
+		devs = devs_2;
+
+	}
+	else if (devs_2_pro != NULL) {
+		cur_dev = devs_2_pro;
+		devs = devs_2_pro;
+	}
 	hid_device* device = NULL;
 
 	while (devs) {

--- a/AirAPI_Windows.sln
+++ b/AirAPI_Windows.sln
@@ -13,8 +13,8 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0A770089-877A-4053-957D-2F56EA425766}.Debug|x64.ActiveCfg = Debug|x64
-		{0A770089-877A-4053-957D-2F56EA425766}.Debug|x64.Build.0 = Debug|x64
+		{0A770089-877A-4053-957D-2F56EA425766}.Debug|x64.ActiveCfg = Release|x64
+		{0A770089-877A-4053-957D-2F56EA425766}.Debug|x64.Build.0 = Release|x64
 		{0A770089-877A-4053-957D-2F56EA425766}.Debug|x86.ActiveCfg = Debug|Win32
 		{0A770089-877A-4053-957D-2F56EA425766}.Debug|x86.Build.0 = Debug|Win32
 		{0A770089-877A-4053-957D-2F56EA425766}.Release|x64.ActiveCfg = Release|x64

--- a/AirAPI_Windows.vcxproj
+++ b/AirAPI_Windows.vcxproj
@@ -144,7 +144,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <AdditionalDependencies>Fusion.lib;hidapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ProjectDir)\deps\hidapi-win\x64;$(ProjectDir)\deps\Fusion\Fusion\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)\deps\hidapi-win\x64;$(ProjectDir)\deps\Fusion\Fusion\Release;%(AdditionalLibraryDirectories):$(ProjectDir)\deps\hidapi-win\x64;$(ProjectDir)\deps\Fusion\Fusion\out\build\x64-Debug\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixed no return value in interface4Handler. Fixed file path to match the actual default build location of fusion. Set default project type to release.


